### PR TITLE
Fix windows compatibility and add a readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Gulp systemjs module name injector
+
+This plugin was created to aid with the TypeScript module system.
+When TypeScript files are compiled using the `--module system` flag, the compiler does not output module names.
+
+An example:
+
+    System.register(["./other/module/dependency"], function($_export) {
+      // ... module
+    });
+
+The output is totally unusable, since the module doesn't have a name. This plugin converts the output to this:
+
+    System.register("module/path", ["./other/module/dependency"], function($_export) {
+      // ... module
+    });
+
+## Usage
+
+Install the plugin:
+
+    npm install gulp-systemjs-module-name-injector --save-dev
+    
+In your gulpfile:
+
+    var systemjsModuleName = require('gulp-systemjs-module-name-injector');
+    
+    function buildTypescript() {
+        return gulp.src(/* ... */)
+            .pipe(typescript(tsProject))
+            .pipe(systemjsModuleName())
+            .pipe(/* ... */);
+    }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@
 var Transform = require('readable-stream/transform');
 var rs = require('replacestream');
 
+var jsExtensionRegex = /\.js/;
+var windowsBackwardSlashRegex = /\\/g;
+
 module.exports = function () {
     return new Transform({
         objectMode: true,
@@ -15,7 +18,10 @@ module.exports = function () {
                 return callback(Error('Only streams and buffers are supported.'), file);
             }
 
-            var name = file.relative.replace(/\.js/, '');
+            var name = file.relative
+                .replace(jsExtensionRegex, '')
+                .replace(windowsBackwardSlashRegex, '/');
+
             var search = /^System\.register\(\[/;
             var replace = "System.register('" + name + "', [";
 


### PR DESCRIPTION
On Windows `file.relative` contains backslashes but System.js fails to resolve the modules correctly.
